### PR TITLE
Fix account creation

### DIFF
--- a/index.php
+++ b/index.php
@@ -115,7 +115,7 @@ $account = createAccount();
         <div class="infoo">
         Welcome on <span style="color: #3590d7; font-size: 22px;"><strong>Private Realm</strong></span>.
         <br>
-        Project is only for learning purpouse.
+        This project is only for learning purposes.
         <br><br><br>
         </div>
 
@@ -136,7 +136,7 @@ $account = createAccount();
             <div class="information">
                 <ul>
                     <li>This is a Private Realm!</li>
-                    <li>This realm is for private purpouse only!</li>
+                    <li>This realm is for private purposes only!</li>
                     <br>
                     <li>The realmlist is <pre>set realmlist ***</pre></li>
                 </ul>

--- a/lib/account.php
+++ b/lib/account.php
@@ -19,7 +19,9 @@ class account
             $this->password[1] = $post['password_repeat'];
         }
         else
+        {
             $this->errors[] = "Please fill all required fields.";
+        }
     }
 
     private function validateDataArray(array $data)
@@ -52,19 +54,63 @@ class account
         return count($this->errors) > 0;
     }
 
-    private function getPasswordHash()
+    private static function generateSalt()
     {
-        return sha1(strtoupper($this->username).":".strtoupper($this->password[0]));
+        return random_bytes(32);
+    }
+
+    private static function getVerifier($username, $password, $salt)
+    {
+        // algorithm constants
+        $g = gmp_init(7);
+        $N = gmp_init('894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7', 16);
+
+        // calculate first hash
+        $h1 = sha1(strtoupper($username . ':' . $password), true);
+
+        // calculate second hash
+        $h2 = sha1($salt . $h1, true);
+
+        // convert to integer (little-endian)
+        $h2 = gmp_import($h2, 1, GMP_LSW_FIRST);
+
+        // g^h2 mod N
+        $verifier = gmp_powm($g, $h2, $N);
+
+        // convert back to a byte array (little-endian)
+        $verifier = gmp_export($verifier, 1, GMP_LSW_FIRST);
+
+        // pad to 32 bytes, remember that zeros go on the end in little-endian!
+        $verifier = str_pad($verifier, 32, chr(0), STR_PAD_RIGHT);
+
+        return $verifier;
+    }
+
+    function verifyLogin($salt, $verifier)
+    {
+        // re-calculate the verifier using the provided username + password and the stored salt
+        $checkVerifier = account::getVerifier($this->username, $this->password[0], $salt);
+
+        // compare it against the stored verifier
+        return ($verifier === $checkVerifier);
     }
 
     public function saveToDb()
     {
         if (count($this->errors) !== 0)
+        {
             return account::STATUS_FAILED;
+        }
 
         if (!$this->validatePassword())
         {
             $this->errors[] = "Passwords do not match.";
+            return account::STATUS_FAILED;
+        }
+
+        if (strlen($this->password[0]) > 16)
+        {
+            $this->errors[] = "Password must be at most 16 characters long.";
             return account::STATUS_FAILED;
         }
 
@@ -79,12 +125,21 @@ class account
             return account::STATUS_FAILED;
         }
 
-        $passHash = $this->getPasswordHash();
+        $salt = account::generateSalt();
+        $verifier = account::getVerifier($this->username, $this->password[0], $salt);
 
-        $stmt = $db->prepare("INSERT INTO account (username, sha_pass_hash, expansion) VALUES (:username, :password, 2)");
+        $stmt = $db->prepare("INSERT INTO account (username, salt, verifier, expansion) VALUES (:username, :salt, :verifier, 2)");
         $stmt->bindParam(":username", $this->username);
-        $stmt->bindParam(":password", $passHash);
-        $stmt->execute();
+        $stmt->bindParam(":salt", $salt);
+        $stmt->bindParam(":verifier", $verifier);
+        $res = $stmt->execute();
+
+        if (!$res)
+        {
+            $err = $stmt->errorInfo();
+            $this->errors[] = "Error " . $err[0] . " occurred: " . $err[2];
+            return account::STATUS_FAILED;
+        }
 
         return account::STATUS_OK;
     }

--- a/module/create_account.php
+++ b/module/create_account.php
@@ -3,7 +3,9 @@
 function createAccount()
 {
     if (!isset($_POST['signup']))
+    {
         return new account(['username' => '', 'password' => '', 'password_repeat' => '']);
+    }
 
     $account = new account($_POST);
     $result = $account->saveToDb();


### PR DESCRIPTION
* Replaced sha1 password hash with SRP6 salt and verifier
* Now returns a proper error message when there is a database error while creating the account
* Now returns an error if the password is longer than 16 characters (not supported by client)